### PR TITLE
[#90] remove name and age from one time tickets

### DIFF
--- a/src/api/v1/orders/post.order.ts
+++ b/src/api/v1/orders/post.order.ts
@@ -582,8 +582,8 @@ const createTicketWithProfile = async (
 			profile: {
 				id: profileId,
 				email: user.email,
-				name: user.name,
-				age: user.age,
+				name: ticketType.nameRequired ? user.name : null,
+				age: ticketType.nameRequired ? user.age : null,
 				zip: user.zip,
 			},
 		},


### PR DESCRIPTION
For tickets where name or age is not required we will not save it when creating Profile.