### PR TITLE
Add health endpoint and k8s probes for zero-downtime rollouts

### DIFF
--- a/kubernetes/base/deployment.yml
+++ b/kubernetes/base/deployment.yml
@@ -12,6 +12,12 @@ metadata:
         image: ${IMAGE}
 spec:
     replicas: 1
+    minReadySeconds: 5
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 1
+            maxUnavailable: 0
     selector:
         matchLabels:
             service: app
@@ -35,6 +41,20 @@ spec:
                       requests:
                           cpu: 50m
                           memory: 64Mi
+                  readinessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+                      failureThreshold: 6
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: http
+                      initialDelaySeconds: 30
+                      periodSeconds: 15
+                      failureThreshold: 3
                   envFrom:
                       - secretRef:
                             name: app-secret

--- a/src/app.ts
+++ b/src/app.ts
@@ -144,6 +144,9 @@ app.use(passport.initialize())
 // i18n module
 app.use(i18nextMiddleware.handle(i18next))
 
+// health check endpoint for kubernetes probes
+app.get('/health', (_req, res) => res.status(200).json({ status: 'ok' }))
+
 app.use('/api/v1', routerV1())
 app.use('/api/admin', routerAdmin())
 


### PR DESCRIPTION
## Problem

The Deployment had no `readinessProbe`, so kubernetes marked a new pod **Ready the moment the container process started** — before Express bound the port or workers initialized. With the default rolling update this meant the old pod was killed immediately, causing a brief window of dropped/erroring requests on **every deploy**.

## Changes

**`src/app.ts`**
- New `GET /health` endpoint returning `200 {"status":"ok"}`

**`kubernetes/base/deployment.yml`**
- `readinessProbe` (httpGet `/health`) — rollout now waits until the app actually serves traffic before terminating the old pod
- `livenessProbe` (httpGet `/health`) — restarts a hung-but-running pod
- Explicit `RollingUpdate` strategy with `maxSurge: 1`, `maxUnavailable: 0` (matches defaults, makes intent visible)
- `minReadySeconds: 5` settle window

## Result

Zero-downtime rollouts even with `replicas: 1`: new pod must pass `/health` before the old one is terminated.

## Verification

- `kustomize build kubernetes/envs/Dev` renders probes, strategy, and `minReadySeconds` correctly
- `tsc --noEmit`: no new errors (2 pre-existing missing-type-lib errors unchanged)
- After deploy to Dev: rollout status should wait on readiness; continuous `curl` across a deploy should show no 5xx/connection-refused gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)