### PR TITLE
Increase DB resource limits to 1 CPU / 2Gi

### DIFF
--- a/kubernetes/base/statefulSet.yml
+++ b/kubernetes/base/statefulSet.yml
@@ -25,8 +25,8 @@ spec:
                         protocol: TCP
                   resources:
                       limits:
-                          cpu: 500m
-                          memory: 1Gi
+                          cpu: 1
+                          memory: 2Gi
                       requests:
                           cpu: 100m
                           memory: 128Mi


### PR DESCRIPTION
Raises the Postgres StatefulSet limits from `500m/1Gi` to `1/2Gi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)