### PR TITLE
Increase DB resource limits to 2 CPU / 4Gi

### DIFF
--- a/kubernetes/base/statefulSet.yml
+++ b/kubernetes/base/statefulSet.yml
@@ -25,8 +25,8 @@ spec:
                         protocol: TCP
                   resources:
                       limits:
-                          cpu: 1
-                          memory: 2Gi
+                          cpu: 2
+                          memory: 4Gi
                       requests:
                           cpu: 100m
                           memory: 128Mi


### PR DESCRIPTION
Doubles the Postgres StatefulSet limits from `1/2Gi` to `2/4Gi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)