### PR TITLE
252 add error handling for GP Webservice when request is valid

### DIFF
--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -355,8 +355,11 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 			return value
 		}
 
-		// GP is returning, for valid request (example is when sending request has OrderNumber that is not visited and therefore not yet consumed by GP),
-		// response 500, we need to act as it is fine and return undefined.
+		// GP returns HTTP 500 for some valid requests — e.g. when the OrderNumber
+		// hasn't been visited at GP site yet from user so GP doesn't know it.
+		// This isn't a real error coming from bad request,
+		// so we treat it regular 200 response process this response
+		// and in this case return undefined.
 
 		// TODO we should use axios
 		if (response.status === 500) {

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -1,6 +1,8 @@
 import formurlencoded from 'form-urlencoded'
 import fs from 'fs'
 import config from 'config'
+import Joi from 'joi'
+import xml2js from 'xml2js'
 import { models } from '../db/models'
 import { PaymentResponseModel } from '../db/models/paymentResponse'
 import { createSignature, verifySignature } from '../utils/webpay'
@@ -20,6 +22,48 @@ const appConfig: IAppConfig = config.get('app')
 const webpayConfig: IGPWebpayConfig = config.get('gpWebpayService')
 
 const gpPaymentServiceURL = `${webpayConfig.httpApi}/pay-ws/v1/PaymentService`
+
+export const gpWebservicePaymentStatusErrorSchema = Joi.object({
+	'soapenv:Envelope': Joi.object().keys({
+		$: Joi.object().keys({
+			'xmlns:soapenv': Joi.string(),
+		}),
+		'soapenv:Body': Joi.array()
+			.required()
+			.min(1)
+			.items({
+				'soapenv:Fault': Joi.array()
+					.min(1)
+					.required()
+					.items({
+						faultcode: Joi.array().required().items(Joi.string()),
+						faultstring: Joi.array().required().items(Joi.string()),
+						detail: Joi.array()
+							.min(1)
+							.required()
+							.items({
+								'ns4:serviceException': Joi.array()
+									.min(1)
+									.required()
+									.items({
+										$: Joi.object()
+											.keys({
+												'xmlns:ns4': Joi.string(),
+												'xmlns:ns5': Joi.string(),
+												'xmlns:ns3': Joi.string(),
+												'xmlns:ns2': Joi.string(),
+											})
+											.unknown(true),
+										'ns3:messageId': Joi.array().required().items(Joi.string()),
+										'ns3:primaryReturnCode': Joi.array().required().items(Joi.string()),
+										'ns3:secondaryReturnCode': Joi.array().required().items(Joi.string()),
+										'ns3:signature': Joi.array().required().items(Joi.string()),
+									}),
+							}),
+					}),
+			}),
+	}),
+})
 
 export const checkPaymentKeys = () => {
 	try {
@@ -205,6 +249,9 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 
 	const now = new Date()
 
+	// TODO add "orderNumber" to messageId so we can trace back to what order this requests belongs
+	// now we are dependent on synchronicity of this process and when requesting then we
+	// are await-ing for response that way it works for now
 	const messageId = `${now.getTime()}${provider}${merchantNumber}getPaymentStatus`
 
 	const requestObject = {
@@ -227,7 +274,6 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		paymentNumber: orderNumber,
 		signature,
 	}
-
 	const requestBody = `<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:v1='http://gpe.cz/pay/pay-ws/proc/v1' xmlns:type='http://gpe.cz/pay/pay-ws/proc/v1/type'><soapenv:Header/><soapenv:Body><v1:getPaymentStatus><v1:paymentStatusRequest><type:messageId>${paymentStatusRequestObject.messageId}</type:messageId><type:provider>${paymentStatusRequestObject.provider}</type:provider><type:merchantNumber>${paymentStatusRequestObject.merchantNumber}</type:merchantNumber><type:paymentNumber>${paymentStatusRequestObject.paymentNumber}</type:paymentNumber><type:signature>${paymentStatusRequestObject.signature}</type:signature></v1:paymentStatusRequest></v1:getPaymentStatus></soapenv:Body></soapenv:Envelope>`
 	const response = await fetch(gpPaymentServiceURL, {
 		method: 'post',
@@ -235,16 +281,39 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		headers: { 'Content-Type': 'text/xml' },
 	})
 
-	if (!response.ok) {
-		logger.error(httpErrorStatusString(response))
-
-		logger.error(`Error body: ${await response.text()}`)
-
-		throw new ErrorBuilder(
-			500,
-			`Error occurred while fetching paymentService from "${gpPaymentServiceURL}"`
-		)
+	if (response.ok) {
+		return response
 	}
+	const data = await response.text()
 
-	return response
+	// GP is returning for valid request (example is when sending request has OrderNumber that is not visited and therefore not yet consumed by GP),
+	// response 500, we need to act as it is fine and return undefined.
+
+	// TODO we should use axios
+	if (response.status === 500) {
+		try {
+			const parser = new xml2js.Parser()
+			const parsedBody = await parser.parseStringPromise(data)
+			const { error: validateErrorSchemaError } =
+				gpWebservicePaymentStatusErrorSchema.validate(parsedBody)
+
+			// this is 500 from GP but request was possibly valid and response should not be 500
+			if (!validateErrorSchemaError) {
+				// all return codes can be found in https://portal.gpwebpay.com/portal/tools/GP_webpay_WS_API.pdf part 5.2
+				logger.warn(`GP Response that shouldn't be 500 but it is: ${data}`)
+				return undefined
+			}
+		} catch (error) {
+			logger.warn(
+				`Error occurred while parsing XML and validating paymentService from "${gpPaymentServiceURL}"`
+			)
+		}
+	}
+	logger.error(httpErrorStatusString(response))
+
+	logger.error(`Error body: ${data}`)
+	throw new ErrorBuilder(
+		500,
+		`Error occurred while fetching paymentService from "${gpPaymentServiceURL}"`
+	)
 }

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -362,9 +362,9 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		if (response.status === 500) {
 			const parsed = gpWebservicePaymentStatusErrorSchema.safeParse(parsedBody)
 			if (!parsed.success) {
-				logger.warn(`Error while parsing ${parsed.error}`)
+				logger.warn(`Error while parsing GP response: ${parsed.error}`)
 			} else {
-				logger.warn(`GP Response that shouldn't be 500 but it is: ${parsed.data}`)
+				logger.warn(`GP Response that shouldn't be 500 but it is: ${JSON.stringify(parsed.data)}`)
 				const serviceException =
 					parsed.data['soapenv:Envelope']['soapenv:Body'][0]['soapenv:Fault'][0]['detail'][0][
 						'ns4:serviceException'
@@ -372,10 +372,10 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 				const prCode = serviceException['ns3:primaryReturnCode'][0]
 				const process = getProcessingStrategy(prCode)
 				if (!process.shouldAlert) {
-					logger.warn(`Handled PR code: ${prCode}`)
+					logger.warn(`GP response handled PR code: ${prCode}`)
 					return undefined
 				}
-				logger.warn(`Error unhandled PR code: ${prCode}`)
+				logger.warn(`GP response error, unhandled PR code: ${prCode}`)
 			}
 		}
 	} catch (error) {

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -274,7 +274,25 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		paymentNumber: orderNumber,
 		signature,
 	}
-	const requestBody = `<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:v1='http://gpe.cz/pay/pay-ws/proc/v1' xmlns:type='http://gpe.cz/pay/pay-ws/proc/v1/type'><soapenv:Header/><soapenv:Body><v1:getPaymentStatus><v1:paymentStatusRequest><type:messageId>${paymentStatusRequestObject.messageId}</type:messageId><type:provider>${paymentStatusRequestObject.provider}</type:provider><type:merchantNumber>${paymentStatusRequestObject.merchantNumber}</type:merchantNumber><type:paymentNumber>${paymentStatusRequestObject.paymentNumber}</type:paymentNumber><type:signature>${paymentStatusRequestObject.signature}</type:signature></v1:paymentStatusRequest></v1:getPaymentStatus></soapenv:Body></soapenv:Envelope>`
+	const requestBody = `
+		<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/' xmlns:v1='http://gpe.cz/pay/pay-ws/proc/v1' xmlns:type='http://gpe.cz/pay/pay-ws/proc/v1/type'>
+			<soapenv:Header/>
+			<soapenv:Body>
+				<v1:getPaymentStatus>
+					<v1:paymentStatusRequest>
+						<type:messageId>${paymentStatusRequestObject.messageId}</type:messageId>
+						<type:provider>${paymentStatusRequestObject.provider}</type:provider>
+						<type:merchantNumber>${paymentStatusRequestObject.merchantNumber}</type:merchantNumber>
+						<type:paymentNumber>${paymentStatusRequestObject.paymentNumber}</type:paymentNumber>
+						<type:signature>${paymentStatusRequestObject.signature}</type:signature>
+					</v1:paymentStatusRequest>
+				</v1:getPaymentStatus>
+			</soapenv:Body>
+		</soapenv:Envelope>
+	`
+		// string adjustment to keep formatting in code but send it as one line
+		.replace(/>\s+</g, '><')
+		.trim()
 	const response = await fetch(gpPaymentServiceURL, {
 		method: 'post',
 		body: requestBody,

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -294,10 +294,7 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 
 	const now = new Date()
 
-	// TODO add "orderNumber" to messageId so we can trace back to what order this requests belongs
-	// now we are dependent on synchronicity of this process and when requesting then we
-	// are await-ing for response that way it works for now
-	const messageId = `${now.getTime()}${provider}${merchantNumber}getPaymentStatus`
+	const messageId = `${orderNumber}${now.getTime()}${provider}${merchantNumber}getPaymentStatus`
 
 	const requestObject = {
 		messageId,

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -2,6 +2,7 @@ import formurlencoded from 'form-urlencoded'
 import fs from 'fs'
 import config from 'config'
 import Joi from 'joi'
+import { z } from 'zod'
 import xml2js from 'xml2js'
 import { models } from '../db/models'
 import { PaymentResponseModel } from '../db/models/paymentResponse'
@@ -18,12 +19,13 @@ import { logger } from '../utils/logger'
 import ErrorBuilder from '../utils/ErrorBuilder'
 import { httpErrorStatusString } from '../utils/helpers'
 
-const appConfig: IAppConfig = config.get('app')
-const webpayConfig: IGPWebpayConfig = config.get('gpWebpayService')
+interface GpWebpayProcessingStrategy {
+	shouldAlert: boolean
+}
 
-const gpPaymentServiceURL = `${webpayConfig.httpApi}/pay-ws/v1/PaymentService`
+const gpPaymentArraySchema = Joi.array().required().items(Joi.string())
 
-export const gpWebservicePaymentStatusErrorSchema = Joi.object({
+const gpWebservicePaymentStatusSchema = Joi.object({
 	'soapenv:Envelope': Joi.object().keys({
 		$: Joi.object().keys({
 			'xmlns:soapenv': Joi.string(),
@@ -32,36 +34,79 @@ export const gpWebservicePaymentStatusErrorSchema = Joi.object({
 			.required()
 			.min(1)
 			.items({
-				'soapenv:Fault': Joi.array()
+				'ns4:getPaymentStatusResponse': Joi.array()
 					.min(1)
 					.required()
 					.items({
-						faultcode: Joi.array().required().items(Joi.string()),
-						faultstring: Joi.array().required().items(Joi.string()),
-						detail: Joi.array()
+						$: Joi.object().keys({
+							'xmlns:ns4': Joi.string(),
+							xmlns: Joi.string(),
+							'xmlns:ns5': Joi.string(),
+							'xmlns:ns3': Joi.string(),
+							'xmlns:ns2': Joi.string(),
+						}),
+						'ns4:paymentStatusResponse': Joi.array()
 							.min(1)
 							.required()
 							.items({
-								'ns4:serviceException': Joi.array()
-									.min(1)
-									.required()
-									.items({
-										$: Joi.object()
-											.keys({
-												'xmlns:ns4': Joi.string(),
-												'xmlns:ns5': Joi.string(),
-												'xmlns:ns3': Joi.string(),
-												'xmlns:ns2': Joi.string(),
-											})
-											.unknown(true),
-										'ns3:messageId': Joi.array().required().items(Joi.string()),
-										'ns3:primaryReturnCode': Joi.array().required().items(Joi.string()),
-										'ns3:secondaryReturnCode': Joi.array().required().items(Joi.string()),
-										'ns3:signature': Joi.array().required().items(Joi.string()),
-									}),
+								'ns3:messageId': gpPaymentArraySchema,
+								'ns3:state': gpPaymentArraySchema,
+								'ns3:status': Joi.array().min(1).required().items(Joi.string()),
+								'ns3:subStatus': gpPaymentArraySchema,
+								'ns3:signature': gpPaymentArraySchema,
 							}),
 					}),
 			}),
+	}),
+})
+
+const appConfig: IAppConfig = config.get('app')
+const webpayConfig: IGPWebpayConfig = config.get('gpWebpayService')
+
+const gpPaymentServiceURL = `${webpayConfig.httpApi}/pay-ws/v1/PaymentService`
+
+const gpStringArray = z.array(z.string())
+
+const gpServiceExceptionSchema = z.object({
+	$: z.looseObject({
+		'xmlns:ns4': z.string(),
+		'xmlns:ns5': z.string(),
+		'xmlns:ns2': z.string(),
+		'xmlns:ns3': z.string(),
+	}),
+	'ns3:messageId': gpStringArray,
+	'ns3:primaryReturnCode': gpStringArray,
+	'ns3:secondaryReturnCode': gpStringArray,
+	'ns3:signature': gpStringArray,
+})
+
+const gpFaultSchema = z.object({
+	faultcode: gpStringArray,
+	faultstring: gpStringArray,
+	detail: z
+		.array(
+			z.object({
+				'ns4:serviceException': z.array(gpServiceExceptionSchema).min(1),
+			})
+		)
+		.min(1),
+})
+
+// xml2js wraps every element in an array and puts XML attributes under `$`.
+export const gpWebservicePaymentStatusErrorSchema = z.object({
+	'soapenv:Envelope': z.object({
+		$: z
+			.looseObject({
+				'xmlns:soapenv': z.string(),
+			})
+			.optional(),
+		'soapenv:Body': z
+			.array(
+				z.object({
+					'soapenv:Fault': z.array(gpFaultSchema).min(1),
+				})
+			)
+			.min(1),
 	}),
 })
 
@@ -298,34 +343,46 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		body: requestBody,
 		headers: { 'Content-Type': 'text/xml' },
 	})
-
-	if (response.ok) {
-		return response
-	}
 	const data = await response.text()
 
-	// GP is returning for valid request (example is when sending request has OrderNumber that is not visited and therefore not yet consumed by GP),
-	// response 500, we need to act as it is fine and return undefined.
+	try {
+		const parser = new xml2js.Parser()
+		const parsedBody = await parser.parseStringPromise(data)
 
-	// TODO we should use axios
-	if (response.status === 500) {
-		try {
-			const parser = new xml2js.Parser()
-			const parsedBody = await parser.parseStringPromise(data)
-			const { error: validateErrorSchemaError } =
-				gpWebservicePaymentStatusErrorSchema.validate(parsedBody)
-
-			// this is 500 from GP but request was possibly valid and response should not be 500
-			if (!validateErrorSchemaError) {
-				// all return codes can be found in https://portal.gpwebpay.com/portal/tools/GP_webpay_WS_API.pdf part 5.2
-				logger.warn(`GP Response that shouldn't be 500 but it is: ${data}`)
-				return undefined
+		if (response.ok) {
+			const { error: validateSchemaError, value } =
+				gpWebservicePaymentStatusSchema.validate(parsedBody)
+			if (validateSchemaError) {
+				logger.info(`Error validating GP response: ${validateSchemaError}`)
 			}
-		} catch (error) {
-			logger.warn(
-				`Error occurred while parsing XML and validating paymentService from "${gpPaymentServiceURL}"`
-			)
+			return value
 		}
+
+		// GP is returning, for valid request (example is when sending request has OrderNumber that is not visited and therefore not yet consumed by GP),
+		// response 500, we need to act as it is fine and return undefined.
+
+		// TODO we should use axios
+		if (response.status === 500) {
+			const parsed = gpWebservicePaymentStatusErrorSchema.safeParse(parsedBody)
+			if (!parsed.success) {
+				logger.warn(`Error while parsing ${parsed.error}`)
+			} else {
+				logger.warn(`GP Response that shouldn't be 500 but it is: ${parsed.data}`)
+				const serviceException =
+					parsed.data['soapenv:Envelope']['soapenv:Body'][0]['soapenv:Fault'][0]['detail'][0][
+						'ns4:serviceException'
+					][0]
+				const prCode = serviceException['ns3:primaryReturnCode'][0]
+				const process = getProcessingStrategy(prCode)
+				if (!process.shouldAlert) {
+					logger.warn(`Handled PR code: ${prCode}`)
+					return undefined
+				}
+				logger.warn(`Error unhandled PR code: ${prCode}`)
+			}
+		}
+	} catch (error) {
+		logger.warn(`Error occurred while parsing XML and validating: ${error}`)
 	}
 	logger.error(httpErrorStatusString(response))
 
@@ -334,4 +391,21 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		500,
 		`Error occurred while fetching paymentService from "${gpPaymentServiceURL}"`
 	)
+}
+
+// inspired by https://github.com/bratislava/konto.bratislava.sk/blob/6da01b27184da17dede4146eba6c9142ffd7c96b/nest-tax-backend/src/payment/payment.service.ts#L363
+export const getProcessingStrategy = (prCode: string): GpWebpayProcessingStrategy => {
+	const pr = Number(prCode)
+
+	// https://www.gpwebpay.cz/downloads/GP_webpay_HTTP_EN.pdf
+
+	// PR 15: Object not found
+	if (pr === 15) {
+		return {
+			shouldAlert: false,
+		}
+	}
+	return {
+		shouldAlert: true,
+	}
 }

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -60,11 +60,6 @@ const gpWebservicePaymentStatusSchema = Joi.object({
 	}),
 })
 
-const appConfig: IAppConfig = config.get('app')
-const webpayConfig: IGPWebpayConfig = config.get('gpWebpayService')
-
-const gpPaymentServiceURL = `${webpayConfig.httpApi}/pay-ws/v1/PaymentService`
-
 const gpStringArray = z.array(z.string())
 
 const gpServiceExceptionSchema = z.object({
@@ -109,6 +104,11 @@ export const gpWebservicePaymentStatusErrorSchema = z.object({
 			.min(1),
 	}),
 })
+
+const appConfig: IAppConfig = config.get('app')
+const webpayConfig: IGPWebpayConfig = config.get('gpWebpayService')
+
+const gpPaymentServiceURL = `${webpayConfig.httpApi}/pay-ws/v1/PaymentService`
 
 export const checkPaymentKeys = () => {
 	try {

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -394,6 +394,7 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 export const getProcessingStrategy = (prCode: string): GpWebpayProcessingStrategy => {
 	const pr = Number(prCode)
 
+	// TODO handle other cases
 	// https://www.gpwebpay.cz/downloads/GP_webpay_HTTP_EN.pdf
 
 	// PR 15: Object not found

--- a/src/services/webpayService.ts
+++ b/src/services/webpayService.ts
@@ -1,7 +1,6 @@
 import formurlencoded from 'form-urlencoded'
 import fs from 'fs'
 import config from 'config'
-import Joi from 'joi'
 import { z } from 'zod'
 import xml2js from 'xml2js'
 import { models } from '../db/models'
@@ -23,44 +22,43 @@ interface GpWebpayProcessingStrategy {
 	shouldAlert: boolean
 }
 
-const gpPaymentArraySchema = Joi.array().required().items(Joi.string())
+const gpStringArray = z.array(z.string())
 
-const gpWebservicePaymentStatusSchema = Joi.object({
-	'soapenv:Envelope': Joi.object().keys({
-		$: Joi.object().keys({
-			'xmlns:soapenv': Joi.string(),
-		}),
-		'soapenv:Body': Joi.array()
-			.required()
-			.min(1)
-			.items({
-				'ns4:getPaymentStatusResponse': Joi.array()
-					.min(1)
-					.required()
-					.items({
-						$: Joi.object().keys({
-							'xmlns:ns4': Joi.string(),
-							xmlns: Joi.string(),
-							'xmlns:ns5': Joi.string(),
-							'xmlns:ns3': Joi.string(),
-							'xmlns:ns2': Joi.string(),
-						}),
-						'ns4:paymentStatusResponse': Joi.array()
-							.min(1)
-							.required()
-							.items({
-								'ns3:messageId': gpPaymentArraySchema,
-								'ns3:state': gpPaymentArraySchema,
-								'ns3:status': Joi.array().min(1).required().items(Joi.string()),
-								'ns3:subStatus': gpPaymentArraySchema,
-								'ns3:signature': gpPaymentArraySchema,
-							}),
-					}),
-			}),
-	}),
+const gpWebservicePaymentStatusResponseSchema = z.object({
+	'ns3:messageId': gpStringArray,
+	'ns3:state': gpStringArray,
+	'ns3:status': z.array(z.string()).min(1),
+	'ns3:subStatus': gpStringArray,
+	'ns3:signature': gpStringArray,
 })
 
-const gpStringArray = z.array(z.string())
+const gpGetPaymentStatusResponseSchema = z.object({
+	$: z.looseObject({
+		'xmlns:ns4': z.string(),
+		xmlns: z.string(),
+		'xmlns:ns5': z.string(),
+		'xmlns:ns3': z.string(),
+		'xmlns:ns2': z.string(),
+	}),
+	'ns4:paymentStatusResponse': z.array(gpWebservicePaymentStatusResponseSchema).min(1),
+})
+
+const gpWebservicePaymentStatusSchema = z.object({
+	'soapenv:Envelope': z.object({
+		$: z
+			.looseObject({
+				'xmlns:soapenv': z.string(),
+			})
+			.optional(),
+		'soapenv:Body': z
+			.array(
+				z.object({
+					'ns4:getPaymentStatusResponse': z.array(gpGetPaymentStatusResponseSchema).min(1),
+				})
+			)
+			.min(1),
+	}),
+})
 
 const gpServiceExceptionSchema = z.object({
 	$: z.looseObject({
@@ -347,12 +345,11 @@ export const getPaymentStatusWebServiceRequest = async (orderNumber: number) => 
 		const parsedBody = await parser.parseStringPromise(data)
 
 		if (response.ok) {
-			const { error: validateSchemaError, value } =
-				gpWebservicePaymentStatusSchema.validate(parsedBody)
-			if (validateSchemaError) {
-				logger.info(`Error validating GP response: ${validateSchemaError}`)
+			const parsed = gpWebservicePaymentStatusSchema.safeParse(parsedBody)
+			if (!parsed.success) {
+				logger.info(`Error validating GP response: ${parsed.error}`)
 			}
-			return value
+			return parsed.data
 		}
 
 		// GP returns HTTP 500 for some valid requests — e.g. when the OrderNumber

--- a/src/workers/checkCreatedUnpaidOrders.ts
+++ b/src/workers/checkCreatedUnpaidOrders.ts
@@ -1,6 +1,4 @@
 import { Op } from 'sequelize'
-import Joi from 'joi'
-import xml2js from 'xml2js'
 import { models } from '../db/models'
 import { ORDER_STATE, ORDER_STATE_GPWEBPAY } from '../utils/enums'
 import logger from '../utils/logger'
@@ -8,46 +6,12 @@ import { getPaymentStatusWebServiceRequest } from '../services/webpayService'
 import { sendOrderEmail } from '../utils/emailSender'
 import { markOrderPaid } from '../utils/helpers'
 
-const gpWebservicePaymentStatusSchema = Joi.object({
-	'soapenv:Envelope': Joi.object().keys({
-		$: Joi.object().keys({
-			'xmlns:soapenv': Joi.string(),
-		}),
-		'soapenv:Body': Joi.array()
-			.required()
-			.min(1)
-			.items({
-				'ns4:getPaymentStatusResponse': Joi.array()
-					.min(1)
-					.required()
-					.items({
-						$: Joi.object().keys({
-							'xmlns:ns4': Joi.string(),
-							xmlns: Joi.string(),
-							'xmlns:ns5': Joi.string(),
-							'xmlns:ns3': Joi.string(),
-							'xmlns:ns2': Joi.string(),
-						}),
-						'ns4:paymentStatusResponse': Joi.array()
-							.min(1)
-							.required()
-							.items({
-								'ns3:messageId': Joi.array().required().items(Joi.string()),
-								'ns3:state': Joi.array().required().items(Joi.string()),
-								'ns3:status': Joi.array().min(1).required().items(Joi.string()),
-								'ns3:subStatus': Joi.array().required().items(Joi.string()),
-								'ns3:signature': Joi.array().required().items(Joi.string()),
-							}),
-					}),
-			}),
-	}),
-})
-
 process.on('message', async () => {
 	logger.info('Check created unpaid orders of last 30 minutes.')
 	const { Order } = models
 
 	try {
+		// TODO we should lock this, in case when user visits response endpoint at a same time as this process is running
 		const orders = await Order.findAll({
 			where: {
 				state: ORDER_STATE.CREATED,
@@ -85,49 +49,38 @@ process.on('message', async () => {
 			try {
 				const orderNumber = order.orderNumber
 				logger.info(`Found CREATED order - id: ${orderNumber} checking against GP`)
-				const responseFromGP = await getPaymentStatusWebServiceRequest(orderNumber)
-				if (!responseFromGP) {
-					// TODO gracefully handle GP errors
-					logger.info(`Skipping validating order.orderNumber: ${order.orderNumber}`)
+				const parsedXmlBodyFromGP = await getPaymentStatusWebServiceRequest(orderNumber)
+				if (!parsedXmlBodyFromGP) {
+					logger.info(
+						`Skipping validating order.orderNumber: ${order.orderNumber}, didn't receive proper data.`
+					)
 					continue
 				}
-				const data = await responseFromGP.text()
-				logger.info(`Data from GP received ${data}`)
-				const parser = new xml2js.Parser()
-				let parsedBody = null
 				try {
-					parsedBody = await parser.parseStringPromise(data)
+					const realData =
+						parsedXmlBodyFromGP['soapenv:Envelope']['soapenv:Body'][0][
+							'ns4:getPaymentStatusResponse'
+						][0]['ns4:paymentStatusResponse'][0]
+					const messageId = realData['ns3:messageId'][0]
+					const status = realData['ns3:status'][0]
+					const state = realData['ns3:state'][0]
+					const subStatus = realData['ns3:subStatus'][0]
+					const signature = realData['ns3:signature'][0]
+					// should be used to verify if needed
+					// await verifyDataGetPaymentStatusWebserviceResponse(
+					// 	[messageId, state, status, subStatus],
+					// 	signature
+					// )
 
-					const { error: validateSchemaError, value } =
-						gpWebservicePaymentStatusSchema.validate(parsedBody)
-					if (validateSchemaError) {
-						logger.info(`Error validating GP response: ${validateSchemaError}`)
-					} else {
-						const realData =
-							value['soapenv:Envelope']['soapenv:Body'][0]['ns4:getPaymentStatusResponse'][0][
-								'ns4:paymentStatusResponse'
-							][0]
-						const messageId = realData['ns3:messageId'][0]
-						const status = realData['ns3:status'][0]
-						const state = realData['ns3:state'][0]
-						const subStatus = realData['ns3:subStatus'][0]
-						const signature = realData['ns3:signature'][0]
-						// should be used to verify if needed
-						// await verifyDataGetPaymentStatusWebserviceResponse(
-						// 	[messageId, state, status, subStatus],
-						// 	signature
-						// )
+					if (status === ORDER_STATE_GPWEBPAY.CAPTURED) {
+						logger.info(
+							`Found PAID order without proper status in order - id: ${orderNumber} changing status to PAID and sending email`
+						)
+						const paidNow = await markOrderPaid(order)
 
-						if (status === ORDER_STATE_GPWEBPAY.CAPTURED) {
-							logger.info(
-								`Found PAID order without proper status in order - id: ${orderNumber} changing status to PAID and sending email`
-							)
-							const paidNow = await markOrderPaid(order)
-
-							// only send the email if this call actually paid the order
-							if (paidNow) {
-								await sendOrderEmail(undefined, order.id)
-							}
+						// only send the email if this call actually paid the order
+						if (paidNow) {
+							await sendOrderEmail(undefined, order.id)
 						}
 					}
 				} catch (error) {

--- a/src/workers/checkCreatedUnpaidOrders.ts
+++ b/src/workers/checkCreatedUnpaidOrders.ts
@@ -4,14 +4,11 @@ import xml2js from 'xml2js'
 import { models } from '../db/models'
 import { ORDER_STATE, ORDER_STATE_GPWEBPAY } from '../utils/enums'
 import logger from '../utils/logger'
-import {
-	getPaymentStatusWebServiceRequest,
-	verifyDataGetPaymentStatusWebserviceResponse,
-} from '../services/webpayService'
+import { getPaymentStatusWebServiceRequest } from '../services/webpayService'
 import { sendOrderEmail } from '../utils/emailSender'
 import { markOrderPaid } from '../utils/helpers'
 
-const gpWebserviceSchema = Joi.object({
+const gpWebservicePaymentStatusSchema = Joi.object({
 	'soapenv:Envelope': Joi.object().keys({
 		$: Joi.object().keys({
 			'xmlns:soapenv': Joi.string(),
@@ -89,6 +86,11 @@ process.on('message', async () => {
 				const orderNumber = order.orderNumber
 				logger.info(`Found CREATED order - id: ${orderNumber} checking against GP`)
 				const responseFromGP = await getPaymentStatusWebServiceRequest(orderNumber)
+				if (!responseFromGP) {
+					// TODO gracefully handle GP errors
+					logger.info(`Skipping validating order.orderNumber: ${order.orderNumber}`)
+					continue
+				}
 				const data = await responseFromGP.text()
 				logger.info(`Data from GP received ${data}`)
 				const parser = new xml2js.Parser()
@@ -96,7 +98,8 @@ process.on('message', async () => {
 				try {
 					parsedBody = await parser.parseStringPromise(data)
 
-					const { error: validateSchemaError, value } = gpWebserviceSchema.validate(parsedBody)
+					const { error: validateSchemaError, value } =
+						gpWebservicePaymentStatusSchema.validate(parsedBody)
 					if (validateSchemaError) {
 						logger.info(`Error validating GP response: ${validateSchemaError}`)
 					} else {

--- a/src/workers/checkCreatedUnpaidOrders.ts
+++ b/src/workers/checkCreatedUnpaidOrders.ts
@@ -45,15 +45,17 @@ process.on('message', async () => {
 			order: [['createdAt', 'DESC']],
 		})
 
+		const skippedOrders: { orderNumber: number; reason: string }[] = []
+
 		for (const order of orders) {
 			try {
 				const orderNumber = order.orderNumber
 				logger.info(`Found CREATED order - id: ${orderNumber} checking against GP`)
 				const parsedXmlBodyFromGP = await getPaymentStatusWebServiceRequest(orderNumber)
 				if (!parsedXmlBodyFromGP) {
-					logger.info(
-						`Skipping validating order.orderNumber: ${order.orderNumber}, didn't receive proper data.`
-					)
+					const reason = 'Did not receive proper data from GP webservice for processing.'
+					logger.info(`Skipping validating order.orderNumber: ${order.orderNumber}, ${reason}`)
+					skippedOrders.push({ orderNumber: order.orderNumber, reason })
 					continue
 				}
 				try {
@@ -93,6 +95,9 @@ process.on('message', async () => {
 			}
 		}
 
+		if (skippedOrders.length > 0) {
+			return process.send({ type: 'partial_success', skippedOrders })
+		}
 		return process.send({ type: 'success' })
 	} catch (err) {
 		logger.info(JSON.stringify(err))


### PR DESCRIPTION
- add special error handling in case of Global Payments Web Service endpoint `PaymentStatus` is responding 500 when real response shouldn't be 500
- add additional logging when not handling state above
- add `gpWebservicePaymentStatusErrorSchema`

Closes https://github.com/bratislava/kupaliska-starz-be/issues/252